### PR TITLE
ConCat.Hardware.Verilog: declare modOuts so verilog compiler knows type

### DIFF
--- a/hardware/src/ConCat/Hardware/Verilog.hs
+++ b/hardware/src/ConCat/Hardware/Verilog.hs
@@ -78,6 +78,7 @@ mkModule name cs = Module name
                           ( map (busToReg "")   modIns  ++
                             map (busToReg "_q") modOuts ++
                             map busToNet        modNets ++
+                            map busToNet        modOuts ++
                             [ProcessDecl (Event (ExprVar "clk") PosEdge) Nothing
                               (Seq (map ((\x -> Assign (ExprVar x) (ExprVar (x ++ "_d"))) . busName) modIns ++
                                     map ((\x -> Assign (ExprVar (x ++ "_q")) (ExprVar x)) . busName) modOuts


### PR DESCRIPTION
This program results in following verilog snippet

```{haskell}
test :: (Maybe Int, Maybe Int) -> Int
test (m'a, m'b) = fromMaybe 0xdeadbeef $ do
    a <- m'a
    b <- m'b
    guard $ a > b
    return $ a + b * 10
```

```module MaybeLogic (clk, n0_0_d, n0_1_d, n0_2_d, n0_3_d, n8_0_q);
  input clk;
  input n0_0_d;
  input [31:0] n0_1_d;
  input n0_2_d;
  input [31:0] n0_3_d;
  output [31:0] n8_0_q;
  reg n0_0;
  reg [31:0] n0_1;
  reg n0_2;
  reg [31:0] n0_3;
  reg [31:0] n8_0_q;
  wire [31:0] n2_0;
  wire [31:0] n3_0;
  wire n1_0;
  wire [31:0] n4_0;
  wire [31:0] n5_0;
  wire [31:0] n6_0;
  wire [31:0] n7_0;
  wire [31:0] n8_0; // pull request adds this line, without it verilog compiler (Vivado) assumes n8_0 to be 1 bit wide
  always @(posedge clk)
    begin
      n0_0 <= n0_0_d;
      n0_1 <= n0_1_d;
      n0_2 <= n0_2_d;
      n0_3 <= n0_3_d;
      n8_0_q <= n8_0;
    end
  assign n1_0 = n0_1 > n0_3;
  assign n2_0 = 32'ha;
  assign n3_0 = n0_3 * n2_0;
  assign n4_0 = n0_1 + n3_0;
  assign n5_0 = 32'hdeadbeef;
  assign n6_0 = n1_0 ? n4_0 : n5_0;
  assign n7_0 = n0_2 ? n6_0 : n5_0;
  assign n8_0 = n0_0 ? n7_0 : n5_0;
endmodule


```