### PR TITLE
The function type constructor now has levity arguments.

### DIFF
--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -2266,7 +2266,11 @@ etaReduceN e = e
 
 -- The function category
 funCat :: Cat
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,0,0)
+funCat = mkTyConApp funTyCon [liftedRepDataConTy, liftedRepDataConTy]
+#else
 funCat = mkTyConTy funTyCon
+#endif
 
 liftedExpr :: CoreExpr -> Bool
 liftedExpr e = not (isTyCoDictArg e) && liftedType (exprType e)


### PR DESCRIPTION
Adam Gundry (@adamgundry) found this fix.

This is in line with the already applied fix to isFunCat
in 23de7c5e394e030113b1f5b10487f29491fae163.

With this patch, the golden tests now successfully build
on ghc-8.2.2, but there are 10 test suite failures where
the output is deviating from the expected output in a
subtle way.