### PR TITLE
Compilation with ghc-8.4

### DIFF
--- a/classes/src/ConCat/Additive.hs
+++ b/classes/src/ConCat/Additive.hs
@@ -22,7 +22,8 @@
 module ConCat.Additive where
 
 import Prelude hiding (zipWith)
-import Data.Monoid
+import Data.Monoid (Monoid(..), Sum(..), Product(..))
+import Data.Semigroup (Semigroup(..))
 import Data.Complex hiding (magnitude)
 import Data.Ratio
 import Foreign.C.Types (CSChar, CInt, CShort, CLong, CLLong, CIntMax, CFloat, CDouble)
@@ -184,9 +185,12 @@ instance Applicative Add where
   pure  = abst
   (<*>) = inAbst2 ($)
 
+instance Additive a => Semigroup (Add a) where
+  (<>) = inAbst2 (^+^)
+
 instance Additive a => Monoid (Add a) where
   mempty  = abst zero
-  mappend = inAbst2 (^+^)
+  mappend = (<>)
 
 instance Additive a => Additive (Add a) where
   zero  = mempty

--- a/classes/src/ConCat/Misc.hs
+++ b/classes/src/ConCat/Misc.hs
@@ -31,6 +31,7 @@ import GHC.Types (Constraint)
 import Data.Typeable (Typeable,TypeRep,typeRep,Proxy(..))
 import Data.Data (Data)
 import Data.Monoid (Endo(..))
+import Data.Semigroup (Semigroup(..))
 import Data.Complex (Complex)
 import GHC.Generics hiding (R)
 -- import Unsafe.Coerce (unsafeCoerce)  -- for oops
@@ -165,9 +166,13 @@ instance Newtype Parity where
   pack = Parity
   unpack (Parity x) = x
 
+instance Semigroup Parity where
+  Parity a <> Parity b = Parity (a `xor` b)
+
 instance Monoid Parity where
   mempty = Parity False
-  Parity a `mappend` Parity b = Parity (a `xor` b)
+  mappend = (<>)
+  -- Parity a `mappend` Parity b = Parity (a `xor` b)
 
 boolToInt :: Bool -> Int
 boolToInt c = if c then 1 else 0

--- a/examples/src/ConCat/Free/VectorSpace.hs
+++ b/examples/src/ConCat/Free/VectorSpace.hs
@@ -22,6 +22,7 @@ module ConCat.Free.VectorSpace where
 
 import Prelude hiding (zipWith)
 import Data.Monoid (Sum(..),Product(..))
+import Data.Semigroup (Semigroup(..))
 -- import GHC.Exts (Coercible,coerce)
 import GHC.Generics (U1(..),Par1(..),(:*:)(..),(:+:)(..),(:.:)(..))
 #ifdef VectorSized
@@ -173,9 +174,12 @@ instance HasRep (SumV f a) where
   {-# INLINE abst #-}
   {-# INLINE repr #-}
 
+instance (Zeroable f, Zip f, Num a) => Semigroup (SumV f a) where
+  (<>) = inAbst2 (^+^)
+
 instance (Zeroable f, Zip f, Num a) => Monoid (SumV f a) where
   mempty = abst zeroV
-  mappend = inAbst2 (^+^)
+  mappend = (<>)
 
 sumV :: (Functor m, Foldable m, Zeroable n, Zip n, Num a) => m (n a) -> n a
 sumV = repr . fold . fmap SumV

--- a/graphics/concat-graphics.cabal
+++ b/graphics/concat-graphics.cabal
@@ -34,6 +34,8 @@ library
                      , prettyclass
                      , text >= 1.2.2.1
   default-language:    Haskell2010
+  if impl(ghc >= 8.4)
+    buildable:           False
 
 test-suite graphics-examples
   type:                exitcode-stdio-1.0

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -2266,7 +2266,11 @@ etaReduceN e = e
 
 -- The function category
 funCat :: Cat
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,0,0)
+funCat = mkTyConApp funTyCon [liftedRepDataConTy, liftedRepDataConTy]
+#else
 funCat = mkTyConTy funTyCon
+#endif
 
 liftedExpr :: CoreExpr -> Bool
 liftedExpr e = not (isTyCoDictArg e) && liftedType (exprType e)

--- a/satisfy/src/ConCat/Satisfy/Plugin.hs
+++ b/satisfy/src/ConCat/Satisfy/Plugin.hs
@@ -10,7 +10,7 @@ module ConCat.Satisfy.Plugin where
 import System.IO.Unsafe (unsafePerformIO)
 
 -- GHC API
-import GhcPlugins
+import GhcPlugins as GHC
 import Class (classAllSelIds)
 import MkId (mkDictSelRhs)
 import DynamicLoading
@@ -56,6 +56,6 @@ satisfy _ _ _ _ _ args | pprTrace "satisfyRule" (ppr args) False = undefined
 satisfy hscEnv guts dflags inScope _sat (Type _c : Type _z : f : _) =
   case unsafePerformIO $ buildDictionary hscEnv dflags guts inScope (exprType f) of
     Left  msg  -> pprPanic "satisfy: couldn't build dictionary for" 
-                    (ppr (exprType f) <> colon $$ msg)
+                    (ppr (exprType f) GHC.<> colon $$ msg)
     Right dict -> Just (f `App` dict)
 satisfy _ _ _ _ _ args = pprPanic "satisfy mismatch" (ppr args)

--- a/satisfy/src/ConCat/Simplify.hs
+++ b/satisfy/src/ConCat/Simplify.hs
@@ -1,4 +1,4 @@
--- {-# LANGUAGE #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 
 -- {-# OPTIONS_GHC -fno-warn-unused-imports #-} -- TEMP
@@ -78,7 +78,11 @@ simplEnvForCcc dflags inline
                            , sm_rules = rules_on
                            , sm_inline = inline -- was False
                            , sm_eta_expand = eta_expand_on
-                           , sm_case_case = True }
+                           , sm_case_case = True
+#if MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)
+                           , sm_dflags = dflags
+#endif
+                           }
   where
     rules_on      = gopt Opt_EnableRewriteRules   dflags
     eta_expand_on = gopt Opt_DoLambdaEtaExpansion dflags


### PR DESCRIPTION
This PR includes / depends on #44.

Most of these fixes are originally due to @osa1.

With these changes, the plugin compiles with ghc-8.4, and gold
tests report the same 10 test case failures that they report with ghc-8.2.

Everything still compiles with 8.2 and 8.0.

However, some supporting libraries are still not 8.4-compatible, which results in
failures for some of the concat packages:

- the concat-graphics package depends on language-glsl, which isn't 8.4-compatible.
  @osa1 had submitted a PR for this a long time ago, but no new release has been
  made. We could either depend on a local fork or try to push the upstream authors
  to make a new release.

- the concat-hardware package depens on verilog, which also does not seem to be
  completely 8.4-compatible. It looks like no corresponding PR has been submitted to
  the ku-fpg/netlist repo, so we should probably do that.
