### PR TITLE
Support compilation on GHC 8.6

### DIFF
--- a/classes/src/ConCat/AltCat.hs
+++ b/classes/src/ConCat/AltCat.hs
@@ -21,6 +21,10 @@
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_GHC -Wno-inline-rule-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP

--- a/classes/src/ConCat/Category.hs
+++ b/classes/src/ConCat/Category.hs
@@ -26,6 +26,10 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecursiveDo #-}
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-# OPTIONS_GHC -Wall #-}
 
 -- {-# OPTIONS_GHC -fno-warn-unused-imports #-}  -- TEMP
@@ -52,7 +56,7 @@ import Data.Type.Equality ((:~:)(..))
 import qualified Data.Type.Equality as Eq
 import Data.Type.Coercion (Coercion(..))
 import qualified Data.Type.Coercion as Co
-import GHC.Types (Constraint)
+import GHC.Types (Constraint, Type)
 import Data.Constraint hiding ((&&&),(***),(:=>))
 -- import Debug.Trace
 import Data.Monoid
@@ -306,7 +310,7 @@ class Show2 k where show2 :: a `k` b -> String
 --------------------------------------------------------------------}
 
 class Category k where
-  type Ok k :: * -> Constraint
+  type Ok k :: Type -> Constraint
   type Ok k = Yes1
   id  :: Ok k a => a `k` a
   infixr 9 .
@@ -1240,7 +1244,7 @@ type BiCCC k = (ClosedCat k, CoproductCat k, TerminalCat k, DistribCat k)
 --   toDict (And1 (toDict -> Dict) (toDict -> Dict)) = Dict
 --   unDict = And1 unDict unDict
 
-data Constrained (con :: * -> Constraint) k a b = Constrained (a `k` b)
+data Constrained (con :: Type -> Constraint) k a b = Constrained (a `k` b)
 
 instance (OpSat op con, OpSat op con') => OpCon op (Sat (con &+& con')) where
   inOp :: forall a b. Sat (con &+& con') a && Sat (con &+& con') b |- Sat (con &+& con') (a `op` b)

--- a/examples/src/ConCat/Circuit.hs
+++ b/examples/src/ConCat/Circuit.hs
@@ -42,6 +42,10 @@
 {-# LANGUAGE LiberalTypeSynonyms, ImpredicativeTypes, EmptyDataDecls #-}
 #endif
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- for OkayArr
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
@@ -133,6 +137,7 @@ import Unsafe.Coerce
 -- import GHC.Exts (Coercible) -- ,coerce
 import Data.Typeable (TypeRep,Typeable,eqT,cast) -- ,Proxy(..),typeOf
 import Data.Type.Equality ((:~:)(..))
+import Data.Kind (Type)
 
 import Data.Constraint (Dict(..),(:-)(..),(\\))
 import Data.Pointed (Pointed)
@@ -260,7 +265,7 @@ newSource t templ ins o = -- trace "newSource" $
 -- | Typed aggregate of buses. @'Buses' a@ carries a value of type @a@.
 -- 'AbstB' is for isomorphic forms. Note: b must not have one of the standard
 -- forms. If it does, we'll get a run-time error when consuming.
-data Buses :: * -> * where
+data Buses :: Type -> Type where
   UnitB    :: Buses ()
   PrimB    :: Source -> Buses b
   ProdB    :: Ok2 (:>) a b => Buses a -> Buses b -> Buses (a :* b)
@@ -538,7 +543,7 @@ mkConvertB a -- | Just Refl <- eqT @a @b = a
 type PrimName = String
 
 -- | Primitive of type @a -> b@
-data Template :: * -> * -> * where
+data Template :: Type -> Type -> Type where
   Prim :: PrimName -> Template a b
   Subgraph :: Graph -> BCirc a b -> Template () (a -> b)
 

--- a/examples/src/ConCat/Circuit.hs
+++ b/examples/src/ConCat/Circuit.hs
@@ -420,9 +420,12 @@ genPrimBus = genBus PrimB (ty @a)
 --    flat (ConvertB b) = flat b
 
 unflattenPrimB :: GenBuses a => State [Source] (Buses a)
-unflattenPrimB = do (s:ss) <- M.get
-                    M.put ss
-                    return (PrimB s)
+unflattenPrimB = do ss0 <- M.get
+                    case ss0 of
+                      s:ss -> do M.put ss
+                                 return (PrimB s)
+                      []   -> error "unflattenPrimB: expected non-empty list"
+                                -- TODO: can we do better than raise an error here?
 
 instance GenBuses Bool where
   genBuses' = genPrimBus

--- a/examples/src/ConCat/Nat.hs
+++ b/examples/src/ConCat/Nat.hs
@@ -1,5 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds, TypeOperators, TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-} -- see comment
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+-- Needed to define (*) as a type family
+{-# LANGUAGE NoStarIsType #-}
+#endif
 
 {-# OPTIONS_GHC -Wall #-}
 

--- a/examples/src/ConCat/TArr.hs
+++ b/examples/src/ConCat/TArr.hs
@@ -17,6 +17,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+{-# LANGUAGE NoStarIsType #-}
+#endif
+
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 {-# OPTIONS_GHC -Wno-unused-binds #-}   -- TEMP

--- a/inline/src/ConCat/Inline/Plugin.hs
+++ b/inline/src/ConCat/Inline/Plugin.hs
@@ -80,11 +80,19 @@ inlineClassOp e = pprTrace "inlineClassOp failed/unnecessary" (ppr e) $
 
 lookupRdr :: ModuleName -> (String -> OccName) -> (Name -> CoreM a) -> String -> CoreM a
 lookupRdr modu mkOcc mkThing str =
-  maybe (panic err) mkThing =<<
+  maybe (panic err) mkThing' =<<
     do hsc_env <- getHscEnv
        liftIO (lookupRdrNameInModuleForPlugins hsc_env modu (Unqual (mkOcc str)))
  where
    err = "lookupRdr: couldn't find " ++ str ++ " in " ++ moduleNameString modu
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+   -- In GHC 8.6, lookupRdrNameInModuleForPlugins returns a (Name, Module)
+   -- where earlier it was just a Name
+   mkThing' = mkThing . fst
+#else
+   mkThing' = mkThing
+#endif
 
 lookupTh :: (String -> OccName) -> (Name -> CoreM a) -> String
          -> String -> CoreM a

--- a/inline/src/ConCat/Inline/Plugin.hs
+++ b/inline/src/ConCat/Inline/Plugin.hs
@@ -18,7 +18,11 @@ import MkId (mkDictSelRhs)
 import DynamicLoading
 
 plugin :: Plugin
-plugin = defaultPlugin { installCoreToDos = install }
+plugin = defaultPlugin { installCoreToDos = install
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+                       , pluginRecompile = purePlugin
+#endif
+                       }
 
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install _opts todos =

--- a/known/src/ConCat/Known.hs
+++ b/known/src/ConCat/Known.hs
@@ -24,4 +24,4 @@ nm = Sub Dict
 -- knownAdd = Sub Dict
 
 KNOW(knownAdd,+)
-KNOW(knownMul,*)
+KNOW(knownMul,GHC.TypeLits.*)

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -1739,7 +1739,11 @@ install opts todos =
           -- pprTrace "ccc post-install todos:" (ppr (pre ++ ours ++ post)) (return ())
           return $ pre ++ ours ++ post
  where
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+   flagCcc :: CccEnv -> CorePluginPass
+#else
    flagCcc :: CccEnv -> PluginPass
+#endif
    flagCcc (CccEnv {..}) guts
      | showCcc && pprTrace "ccc final:" (ppr (mg_binds guts)) False = undefined
      | not (Seq.null remaining) &&

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -297,7 +297,7 @@ ccc (CccEnv {..}) (Ops {..}) cat =
 #if 1
      Trying("top nominal Cast")
      Cast e co@( -- dtrace "top nominal cast co" (pprCoWithType co {-<+> (ppr (setNominalRole_maybe co))-}) id
-                setNominalRole_maybe -> Just (reCatCo -> Just co')) ->
+                setNominalRole_maybe' -> Just (reCatCo -> Just co')) ->
        -- etaExpand turns cast lambdas into themselves
        Doing("top nominal cast")
        let co'' = downgradeRole (coercionRole co) (coercionRole co') co' in
@@ -768,7 +768,7 @@ ccc (CccEnv {..}) (Ops {..}) cat =
            Case (inlineE abst `App` (repr `App` scrut)) v altsTy alts
 #endif
      Trying("lam nominal Cast")
-     Cast body' co@(setNominalRole_maybe -> Just co') ->
+     Cast body' co@(setNominalRole_maybe' -> Just co') ->
        -- etaExpand turns cast lambdas into themselves
        Doing("lam nominal cast")
        let r  = coercionRole co
@@ -2433,6 +2433,13 @@ setNominalRole_maybe' (UnivCo prov _ co1 co2)
                  HoleProv _       -> False  -- no no no.
   = Just $ UnivCo prov Nominal co1 co2
 setNominalRole_maybe' _ = Nothing
+#endif
+
+setNominalRole_maybe' :: Coercion -> Maybe Coercion
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+setNominalRole_maybe' c = setNominalRole_maybe (coercionRole c) c
+#else
+setNominalRole_maybe' = setNominalRole_maybe
 #endif
 
 -- Exists somewhere?

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -2371,7 +2371,11 @@ splitTyConApp_maybe :: Type -> Maybe (TyCon, [Type])
 #endif
 
 starKind :: Kind
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+starKind = liftedTypeKind
+#else
 starKind = mkTyConTy starKindTyCon
+#endif
 
 castE :: Coercion -> CoreExpr
 castE co = Lam x (mkCast (Var x) co)

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -1686,7 +1686,11 @@ cccRules steps famEnvs env@(CccEnv {..}) guts annotations =
     ops = mkOps env guts annotations famEnvs
 
 plugin :: Plugin
-plugin = defaultPlugin { installCoreToDos = install }
+plugin = defaultPlugin { installCoreToDos = install
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+                       , pluginRecompile = purePlugin
+#endif
+                       }
 
 -- Find an option "foo=bar" for optName "foo", returning a read of "bar".
 parseOpt :: Read a => String -> [CommandLineOption] -> Maybe a

--- a/satisfy/src/ConCat/Satisfy/Plugin.hs
+++ b/satisfy/src/ConCat/Satisfy/Plugin.hs
@@ -19,7 +19,11 @@ import ConCat.BuildDictionary (buildDictionary)
 import ConCat.Inline.Plugin (findId)
 
 plugin :: Plugin
-plugin = defaultPlugin { installCoreToDos = install }
+plugin = defaultPlugin { installCoreToDos = install
+#if MIN_VERSION_GLASGOW_HASKELL(8,6,0,0)
+                       , pluginRecompile = purePlugin
+#endif
+                       }
 
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install _opts todos =


### PR DESCRIPTION
This makes it possible to build at least `concat-examples` and its dependencies with the GHC 8.6 beta release. I believe it should now build with 8.0 or later (earlier versions are not supported, please let me know if this is a problem).

To find a build plan it is necessary to specify `allow-newer: base, ghc, Cabal, stm` because not all dependencies have been updated yet. In addition the `vector-sized` package needs a tiny fix to build on 8.6, see expipiplus1/vector-sized#48.

The `verilog` package, a dependency of `concat-hardware`, doesn't build with GHC 8.4 or later. Should `concat-hardware` be marked as unbuildable? (This is similar to the situation with `concat-graphics` due to `language-glsl`, see #45.)

There are two failures due to unexpected output in `gold-tests` on 8.6, [see here for details](https://gist.github.com/adamgundry/e0ff414e95cceb24d1d5b2e61733357c). It's possible that these are harmless changes, I'm not familiar enough with the code, but the differences in `complex-mul-syn` look non-trivial.

In 4490d14 I introduced an explicit call to `error` in place of the previous partial pattern match. Presumably this case doesn't arise in practice, but I thought it should be pointed out.

In 6f98f47 I specify that the plugins should never force recompilation, using the new machinery in GHC 8.6. Is this correct? It may be that a finer-grained recompilation check is needed; I'm not sufficiently familiar with the plugins to know.