### PR TITLE
CI overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,20 +29,26 @@ before_cache:
 matrix:
   include:
 
-    # - compiler: "ghc-8.4.3"
-    # # env: TEST=--disable-tests BENCH=--disable-benchmarks
-    #   addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
-    # - compiler: "ghc-8.2.2"
-    # # env: TEST=--disable-tests BENCH=--disable-benchmarks
-    #   addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.1"
+      env: GHCHEAD=true ALLOW_GOLD_TEST_FAILURES=true
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.6.1], sources: [hvr-ghc]}}
+
+    - compiler: "ghc-8.4.3"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
+
+    - compiler: "ghc-8.2.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.2.2], sources: [hvr-ghc]}}
+
     - compiler: "ghc-8.0.2"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      env: ALLOW_GOLD_TEST_FAILURES=true
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.0.2], sources: [hvr-ghc]}}
-    # - env: CABALVER=head GHCVER=head
-    #   addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
+
+    # - compiler: "ghc-head"
+    #   env: GHCHEAD=true ALLOW_GOLD_TEST_FAILURES=true
+    #   addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 
   allow_failures:
-   - env: CABALVER=head GHCVER=head
+   - compiler: "ghc-head"
 
 before_install:
   - HC=${CC}
@@ -55,6 +61,9 @@ before_install:
   - echo $HCNUMVER
   - echo $(pwd)
   - git clone https://github.com/ku-fpg/netlist.git ../netlist-kit-kufp/
+  - (cd ../netlist-kit-kufp && git checkout 0f50a9cfd947885cac7fc392a5295cffe0b3ac31)
+  - git clone https://github.com/expipiplus1/vector-sized.git ../vector-sized/
+  - (cd ../vector-sized && git checkout f80e3ce774d255ee4ba25fcb12a81a76f600e0b0)
 
 install:
   - cabal --version
@@ -64,21 +73,20 @@ install:
   - HADDOCK=${HADDOCK-true}
   - INSTALLED=${INSTALLED-true}
   - GHCHEAD=${GHCHEAD-false}
+  - ALLOW_GOLD_TEST_FAILURES=${ALLOW_GOLD_TEST_FAILURES-false}
   - travis_retry cabal update -v
   - "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
   - rm -fv cabal.project.local
+  - "if $GHCHEAD; then echo 'allow-newer: base, ghc' > cabal.project.local; fi"
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  # - "printf 'packages: \"graphics\"\\n' > cabal.project"
-  - cat cabal.project
-  # - if [ -f "graphics/configure.ac" ]; then
-      # (cd "graphics" && autoreconf -i);
-    # fi
+  - cat cabal.project || true
+  - cat cabal.project.local || true
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
-  # - cabal new-test
+
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
@@ -99,6 +107,11 @@ script:
   # - cabal new-build -w ${HC} ${TEST} ${BENCH} concat-hardware concat-graphics concat-examples -v0
   # - cabal new-test  concat-hardware concat-graphics concat-examples --ghc-options='-v0' -v0
   # - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
+
+  # check that selected tests can be built and run
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-build -w ${HC} misc-examples graphics-examples hardware-examples; fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-build -w ${HC} gold-tests; fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} gold-tests || $ALLOW_GOLD_TEST_FAILURES; fi
 
   # cabal check
   # - (cd concat-graphics-* && cabal check)

--- a/cabal.project
+++ b/cabal.project
@@ -10,4 +10,6 @@ packages:
           ./examples/concat-examples.cabal
           ./../netlist-kit-kufp/*/*.cabal
           --- cloned from git@github.com:ku-fpg/netlist.git
+          ./../vector-sized/*.cabal
+          --- cloned from git@github.com:expipiplus1/vector-sized.git
 documentation: False

--- a/examples/src/ConCat/TArr.hs
+++ b/examples/src/ConCat/TArr.hs
@@ -49,6 +49,7 @@ import GHC.Types (Nat)
 import GHC.Generics (U1(..),Par1(..),(:*:)(..),(:.:)(..))
 import GHC.Exts (Coercible,coerce)
 
+import Data.Kind (Type)
 import Data.Vector.Sized (Vector)
 import qualified Data.Vector.Generic.Sized.Internal
 import Control.Newtype.Generics
@@ -714,7 +715,7 @@ instance (Decomposable a, Foldable (Decomp a)) => Foldable (Arr a) where
 -- TODO: Maybe use reindexId with just an associated functor.
 
 class Decomposable a where
-  type Decomp a :: * -> *
+  type Decomp a :: Type -> Type
   decomp :: Arr a <--> Decomp a
 
 type Decomposable' a = (Decomposable a, HasFin' a)

--- a/graphics/test/Examples.hs
+++ b/graphics/test/Examples.hs
@@ -24,7 +24,7 @@
 
 -- {-# OPTIONS_GHC -ddump-simpl #-}
 
-{-# OPTIONS_GHC -ddump-rule-rewrites #-}
+-- {-# OPTIONS_GHC -ddump-rule-rewrites #-}
 {-# OPTIONS_GHC -fsimpl-tick-factor=25 #-}  -- default 100
 -- {-# OPTIONS_GHC -fsimpl-tick-factor=250 #-}  -- default 100
 


### PR DESCRIPTION
This adjusts Travis CI so that it builds everything and runs the gold-tests on GHC 8.0.2, 8.2.2, 8.4.3 and 8.6.1.  The actual gold-tests run is permitted to fail on 8.0.2 and 8.6.1, as the expected output for some tests differs between GHC versions, but I think it makes sense to run the tests in CI so as to be able to look at the build log and observe changes in the tests.

I made one small additional fix to support building under GHC 8.6.1, and disabled `-ddump-rule-rewrites` in `graphics-examples` in the interests of speeding up the tests.

Feedback welcome. Are there any other tests we should be running?