### PR TITLE
Support for GHC 8.8

### DIFF
--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -822,9 +822,15 @@ mkOps (CccEnv {..}) guts annotations famEnvs dflags inScope cat = Ops {..}
    reCatCo (FunCo r a b) = Just (mkAppCos (mkReflCo r cat) [a,b])
    reCatCo (splitAppCo_maybe -> Just
             (splitAppCo_maybe -> Just
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+             (GRefl r _k mrefl,a),b)) =
+     -- dtrace "reCatCo app" (ppr (r,_k,a,b)) $
+     Just (mkAppCos (mkGReflCo r cat mrefl) [a,b])
+#else
              (Refl r _k,a),b)) =
      -- dtrace "reCatCo app" (ppr (r,_k,a,b)) $
      Just (mkAppCos (mkReflCo r cat) [a,b])
+#endif
    reCatCo (co1 `TransCo` co2) = TransCo <$> reCatCo co1 <*> reCatCo co2
    reCatCo co = pprTrace "ccc reCatCo: unhandled coercion" (ppr co) $
                 Nothing
@@ -1741,6 +1747,9 @@ onAltRhs f (con,bs,rhs) = (con,bs,f rhs)
 -- To help debug. Sometimes I'm unsure what constructor goes with what ppr.
 coercionTag :: Coercion -> String
 coercionTag Refl        {} = "Refl"
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+coercionTag GRefl        {} = "GRefl"
+#endif
 coercionTag FunCo       {} = "FunCo" -- pattern synonym
 coercionTag TyConAppCo  {} = "TyConAppCo"
 coercionTag AppCo       {} = "AppCo"

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -1715,7 +1715,11 @@ isPred :: CoreExpr -> Bool
 isPred e  = not (isTyCoArg e) && isPredTy' (exprType e)
 
 stringExpr :: String -> CoreExpr
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+stringExpr = Lit . mkLitString
+#else
 stringExpr = Lit . mkMachString
+#endif
 
 varNameExpr :: Id -> CoreExpr
 varNameExpr = stringExpr . uniqVarName

--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -1767,7 +1767,9 @@ coercionTag AxiomRuleCo {} = "AxiomRuleCo"
 coercionTag NthCo       {} = "NthCo"
 coercionTag LRCo        {} = "LRCo"
 coercionTag InstCo      {} = "InstCo"
+#if !MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
 coercionTag CoherenceCo {} = "CoherenceCo"
+#endif
 coercionTag KindCo      {} = "KindCo"
 coercionTag SubCo       {} = "SubCo"
 #if MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)

--- a/satisfy/src/ConCat/BuildDictionary.hs
+++ b/satisfy/src/ConCat/BuildDictionary.hs
@@ -155,8 +155,13 @@ buildDictionary' env dflags guts evIds evar =
                        return z
                    )
           traceTc' "buildDictionary' back from runTcS" (ppr bnds0)
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,0,0)
+          ez <- emptyZonkEnv
+#else
+          let ez = emptyZonkEnv
+#endif
           -- Use the newly exported zonkEvBinds. <https://phabricator.haskell.org/D2088>
-          (_env',bnds) <- zonkEvBinds emptyZonkEnv bnds0
+          (_env',bnds) <- zonkEvBinds ez bnds0
           -- traceTc "buildDictionary' _wCs'" (ppr _wCs')
           -- changed next line from reportAllUnsolved, which panics. revisit and fix!
           -- warnAllUnsolved _wCs'


### PR DESCRIPTION
With theses commits I was able to build most `concat-xxx` packages (except `concat-hardware` and `concat-graphics` that I did not tested) with GHC 8.8.

I tried to keep backward compatibility with GHC 8.6 using `CPP`.

Please review carefully the `Refl -> GRefl` changes, I do admit that I don't really know what I'm doing here.