### PR TITLE
Remove unnecessary Functor constraint.

### DIFF
--- a/classes/src/ConCat/Category.hs
+++ b/classes/src/ConCat/Category.hs
@@ -2005,7 +2005,7 @@ instance (OkFunctor k h, OkFunctor k' h)
       => OkFunctor (k :**: k') h where
   okFunctor = inForkCon (okFunctor @k *** okFunctor @k')
 
-class (Functor h, OkFunctor k h) => FunctorCat k h where
+class OkFunctor k h => FunctorCat k h where
   fmapC :: Ok2 k a b => (a `k` b) -> (h a `k` h b)
   unzipC :: forall a b. Ok2 k a b => h (a :* b) `k` (h a :* h b)
 #if 0


### PR DESCRIPTION
We have categories where non-**Hask** functors can be functors. Here's a
trivial case,

```haskell
data TerminalCategory a b = ZeroId

instance FunctorCat f where
  fmapC ZeroId = ZeroId
```

I don't think there's any way for the plugin to _introduce_ calls to
`fmapC` that apply to a non-Functor, but the constraint seems
superfluous.