### PR TITLE
Activate alternative boxing rules from the paper.

### DIFF
--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -454,6 +454,10 @@ ccc (CccEnv {..}) (Ops {..}) cat =
         sub = [(x,mkEx funCat exlV (Var z)),(y,mkEx funCat exrV (Var z))]
         -- TODO: consider using fst & snd instead of exl and exr here
         mbe' = mkCurry' cat (mkCcc (Lam z (subst sub e)))
+     Trying("lam boxer")
+     (boxCon -> Just e') ->
+       Doing("lam boxer")
+       return (mkCcc (Lam x e'))
      Trying("lam Case of boxer")
      e@(Case scrut wild _ty [(_dc,[unboxedV],rhs)])
        | Just (tc,[]) <- splitTyConApp_maybe (varType wild)

--- a/plugin/src/ConCat/Rebox.hs
+++ b/plugin/src/ConCat/Rebox.hs
@@ -67,7 +67,7 @@ ifEqInt# :: Int# -> Int# -> a -> a -> a
 ifEqInt# m n a b = if equal (boxI m, boxI n) then a else b
 {-# INLINE ifEqInt# #-}
 
-#if 1
+#if 0
 
 #define Rebox1(box,unbox,uop,bop) \
   "rebox2" [~0] uop = \ u# -> unbox (bop (box u#))
@@ -200,7 +200,7 @@ Rebox2(id,unboxIB, leInteger#,lessThanOrEqual)
 "boxF -"      [~0] forall u v . boxF (u `minusFloat#` v) = subC (boxF u,boxF v)
 "boxF *"      [~0] forall u v . boxF (u `timesFloat#` v) = mulC (boxF u,boxF v)
 "boxF exp"    [~0] forall u   . boxF (expFloat# u)       = expC (boxF u)
-"boxF log"    [~0] forall u   . boxF (logFloat# u        = logC(boxF u)
+"boxF log"    [~0] forall u   . boxF (logFloat# u)        = logC(boxF u)
 "boxF cos"    [~0] forall u   . boxF (cosFloat# u)       = cosC (boxF u)
 "boxF sin"    [~0] forall u   . boxF (sinFloat# u)       = sinC (boxF u)
 


### PR DESCRIPTION
This is mainly track the reboxing issue. The gold tests pass, so maybe we can move forward with this.

This requires re-instating the plugin case that actually replaces the
boxing constructors by boxI, boxD etc.

This is in response to #62.