### PR TITLE
Fix GHC-8.10.4 build

### DIFF
--- a/satisfy/src/ConCat/BuildDictionary.hs
+++ b/satisfy/src/ConCat/BuildDictionary.hs
@@ -41,7 +41,13 @@ import TyCoRep (CoercionHole(..), Type(..))
 import TyCon (isTupleTyCon)
 import TcHsSyn (emptyZonkEnv,zonkEvBinds)
 import           TcRnMonad (getCtLocM,traceTc)
+#if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0)
+import Constraint
+import TcOrigin
+import Predicate
+#else
 import           TcRnTypes (cc_ev)
+#endif
 import TcInteract (solveSimpleGivens)
 import TcSMonad -- (TcS,runTcS)
 import TcEvidence (evBindMapBinds)

--- a/satisfy/src/ConCat/Satisfy.hs
+++ b/satisfy/src/ConCat/Satisfy.hs
@@ -13,12 +13,12 @@ module ConCat.Satisfy where
 
 -- | Magic function to satisfy a constraint. Requires -fplugin=ConCat.Satisfy.Plugin to work.
 satisfy :: forall c z. (c => z) -> z
-satisfy = error "satisfy: Use -fplugin=ConCat.Satisfy.Plugin"
+satisfy _ = error "satisfy: Use -fplugin=ConCat.Satisfy.Plugin"
 {-# NOINLINE [0] satisfy #-}
 
 -- The a argument contains a tuple of dictionary variables
 satisfy' :: forall ev c z. ev -> (c => z) -> z
-satisfy' _ = error "satisfy': Use -fplugin=ConCat.Satisfy.Plugin"
+satisfy' _ _ = error "satisfy': Use -fplugin=ConCat.Satisfy.Plugin"
 {-# NOINLINE [0] satisfy' #-}
 
 satisfy1 :: forall c f a. (c f => f a) -> f a


### PR DESCRIPTION
This change enables building the graphics example with ghc-8.10.4
and cabal-install-3.4.0.0 with: `cabal build -O2 graphics-examples`