### PR TITLE
Workable versions of point, zip, zap, zipWith.

### DIFF
--- a/classes/concat-classes.cabal
+++ b/classes/concat-classes.cabal
@@ -43,6 +43,8 @@ library
                        ConCat.Misc
                        ConCat.Rep
                        ConCat.Additive
+                       ConCat.Zip
+                       ConCat.Pointed
                        ConCat.Category
                        ConCat.AltCat
   ghc-options:      -O2

--- a/classes/src/ConCat/AltCat.hs
+++ b/classes/src/ConCat/AltCat.hs
@@ -55,7 +55,10 @@ import Data.Constraint ((\\))
 import Data.Proxy (Proxy)
 import Data.Void
 
-import Data.Pointed
+import Data.Pointed (Pointed)
+import qualified Data.Pointed as Pointed
+import qualified ConCat.Pointed as ConCatPointed
+import qualified ConCat.Zip as ConCatZip
 import Data.Key (Zip(..))
 import Data.Distributive (Distributive(..))
 import Data.Functor.Rep (Representable(..),distributeRep)
@@ -863,7 +866,8 @@ Catify(fmap , fmapC)
 
 Catify(unzip, unzipC)
 Catify(zip  , curry zipC)
-Catify(point, pointC)
+Catify(Pointed.point, pointC)
+Catify(ConCatPointed.point, pointC)
 Catify(sumA , sumAC)
 
 zipWithC :: Zip h => (a -> b -> c) -> (h a -> h b -> h c)
@@ -878,6 +882,9 @@ Catify(zipWith, zipWithC)
 -- Experiment
 Catify(pointNI, pointC)
 Catify(zipWithNI, zipWithC)
+
+Catify(ConCatZip.zipWith, zipWithC)
+Catify(ConCatZip.zip, curry zipC)
 
 #if 0
 unzipC :: forall k h a b. (FunctorCat k h, TerminalCat k, ClosedCat k, Ok2 k a b)
@@ -905,13 +912,13 @@ zapC = fmapC apply . zipC
          <+ okExp     @k    @a @b
 {-# INLINE zapC #-}
 
-Catify(zap, uncurry zapC)
-
 -- TODO: define zapC via zipWithC
 #else
 Op1(zapC, (ZapCat k h, Ok2 k a b) => h (a `k` b) -> (h a `k` h b))
 -- Translation for zap? Maybe like fmap's.
 -- Catify(zap, zapC)  -- 2017-12-27 notes
+Catify(ConCatZip.zap, zapC)
+-- Catify(Aliases.zap, zapC)
 #endif
 
 -- TODO: Is there any value to defining utility functions like unzipC and zapC

--- a/classes/src/ConCat/Pointed.hs
+++ b/classes/src/ConCat/Pointed.hs
@@ -1,31 +1,11 @@
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
-
 {-# OPTIONS_GHC -Wall #-}
--- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
--- | Alternative to Data.Pointed. Temporay (I hope) workaround to a difficulty
--- the plugin sometimes has with single-method classes. See 2018-04-06 notes.
+-- | Aliases for pointed functors, as the ones in Data.Pointed inline too early
+module ConCat.Pointed (Pointed, point) where
 
-module ConCat.Pointed (Pointed(..),point) where
+import qualified Data.Pointed as Pointed
+import Data.Pointed (Pointed)
 
-import Data.Proxy
-
-import qualified Data.Pointed as P
-
-class P.Pointed f => Pointed f where
-  point' :: a -> f a
-  point' = P.point
-  {-# INLINE [0] point' #-}
-  pointedDummy :: Proxy f
-  pointedDummy = Proxy
-
-instance P.Pointed f => Pointed f
-
-point :: Pointed f => a -> f a
-point = point'
+point :: Pointed p => a -> p a
+point = Pointed.point
 {-# INLINE [0] point #-}
--- {-# NOINLINE point #-}
-
--- If & when I get this trick working, find the simplest variant.
--- Do I need two methods in Pointed, or do a superclass and one method suffice?

--- a/classes/src/ConCat/Zip.hs
+++ b/classes/src/ConCat/Zip.hs
@@ -1,0 +1,23 @@
+{-# OPTIONS_GHC -Wall #-}
+
+-- | Aliases for zippable functors, as the ones in Key.Zip inline too early
+module ConCat.Zip(Zip, zipWith, zip, zap) where
+
+-- use with
+-- import Prelude hiding (zipWith, zip)
+
+import Prelude hiding (zipWith, zip)
+import qualified Data.Key as Key
+import Data.Key (Zip)
+
+zipWith :: Zip f => (a -> b -> c) -> f a -> f b -> f c
+zipWith = Key.zipWith
+{-# INLINE [0] zipWith #-}
+
+zip :: Zip f => f a -> f b -> f (a, b)
+zip = Key.zip
+{-# INLINE [0] zip #-}
+
+zap :: Zip f => f (a -> b) -> f a -> f b 
+zap = Key.zap
+{-# INLINE [0] zap #-}


### PR DESCRIPTION
ghc inlines the methods from Data.Key.Zip and Data.Pointed before the
plugin gets there.  Define aliases that do not have this problem.

(There was some code in ConCat.Pointed that seems to have had the same
purpose, but isn't used through the project.)