### PR TITLE
Run the plugin simplifier at phase 2.

### DIFF
--- a/plugin/src/ConCat/Plugin.hs
+++ b/plugin/src/ConCat/Plugin.hs
@@ -1459,7 +1459,7 @@ install opts todos =
      _dflags
 #endif
         = SimplMode { sm_names      = ["Ccc simplifier pass"]
-                    , sm_phase      = Phase 1 -- ??
+                    , sm_phase      = Phase 2 -- avoid inlining i.e. Vector which is at phase 1
                     , sm_rules      = True  -- important
                     , sm_inline     = True -- False -- ??
                     , sm_eta_expand = False -- ??


### PR DESCRIPTION
This avoids prematurely inling libraries that have
INLINEs or RULEs at phase 1, i.e. Vector.