### PR TITLE
Nixify the project's Cabal packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.pdf
 o[1-9]*
 *~
+dist-newstyle/

--- a/nix/concat-overlay.nix
+++ b/nix/concat-overlay.nix
@@ -1,0 +1,47 @@
+self: super:
+let
+  netlistSrc = super.fetchFromGitHub {
+    owner = "ku-fpg";
+    repo = "netlist";
+    rev = "0f50a9cfd947885cac7fc392a5295cffe0b3ac31";
+    sha256 = "tg0UMslWZin6EeUbOruC9jt1xsgYIuk9vGi7uBSOUCw=";
+    fetchSubmodules = true;
+  };
+in {
+  haskellPackages = super.haskellPackages.override {
+    overrides = hself: hsuper:
+      let
+        defaultMod = drv:
+          super.haskell.lib.disableLibraryProfiling
+          (super.haskell.lib.dontHaddock drv);
+        callCabal2nix = hself.callCabal2nix;
+      in {
+        # Prerequisites
+        netlist =
+          defaultMod (callCabal2nix "netlist" (netlistSrc + /netlist) { });
+        verilog =
+          defaultMod (callCabal2nix "netlist" (netlistSrc + /verilog) { });
+        netlist-to-verilog = defaultMod
+          (callCabal2nix "netlist" (netlistSrc + /netlist-to-verilog) { });
+        netlist-to-vhdl = defaultMod
+          (callCabal2nix "netlist" (netlistSrc + /netlist-to-vhdl) { });
+
+        # ConCat packages
+        concat-known = defaultMod (callCabal2nix "concat-known" ../known { });
+        concat-satisfy =
+          defaultMod (callCabal2nix "concat-satisfy" ../satisfy { });
+        concat-inline =
+          defaultMod (callCabal2nix "concat-inline" ../inline { });
+        concat-classes =
+          defaultMod (callCabal2nix "concat-classes" ../classes { });
+        concat-plugin =
+          defaultMod (callCabal2nix "concat-plugin" ../plugin { });
+        concat-examples =
+          defaultMod (callCabal2nix "concat-examples" ../examples { });
+        concat-graphics =
+          defaultMod (callCabal2nix "concat-graphics" ../graphics { });
+        concat-hardware =
+          defaultMod (callCabal2nix "concat-hardware" ../hardware { });
+      };
+  };
+}

--- a/nix/nixpkgs-pin.json
+++ b/nix/nixpkgs-pin.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs.git",
+  "rev": "2bb5ff0da2fc8a37ffb81ffe99b8552bbe5abf83",
+  "date": "2021-02-17T20:18:30-08:00",
+  "path": "/nix/store/0cxsz0m41i37zr5mzcn0kp653ca3x4g8-nixpkgs-2bb5ff0",
+  "sha256": "1dslxrwh6y3dcjqxbnrfdcfyddjzvldzy6i6kz0lhgyf4i20jybk",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/pinned-nixpkgs.nix
+++ b/nix/pinned-nixpkgs.nix
@@ -1,0 +1,13 @@
+let
+  bootstrapPkgs = import <nixpkgs> { };
+  # We create this by using `nix-prefetch-git`, for instance:
+  # nix-prefetch-git --rev foogitrev123 https://github.com/nixos/nixpkgs.git > ./.pinned-nixpkgs.json
+  # The command `nix-prefetch-git` itself can be installed via Nix as well.
+  json = builtins.readFile ./nixpkgs-pin.json;
+  nixpkgs = builtins.fromJSON json;
+  src = bootstrapPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    inherit (nixpkgs) rev sha256;
+  };
+in src

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,5 @@
+let
+  concatOverlay = import ./concat-overlay.nix;
+  nixpkgsSrc = import ./pinned-nixpkgs.nix;
+  pkgs = import nixpkgsSrc { overlays = [ concatOverlay ]; };
+in pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+with import ./nix/pkgs.nix;
+pkgs.haskellPackages.shellFor {
+  buildInputs = [ cabal-install ghc ];
+  packages = p:
+    with pkgs.haskellPackages; [
+      concat-classes
+      concat-examples
+      concat-graphics
+      concat-hardware
+      concat-inline
+      concat-known
+      concat-plugin
+      concat-satisfy
+    ];
+}


### PR DESCRIPTION
This adds an alternative way to develop the project using `cabal-install` by using [Nix](https://nixos.org) to manage the Cabal packages and their (not necessarily Haskell-only) dependencies.

Now it should be possible to simply enter a `nix-shell` in the project root and start building/testing the project with the `cabal` and `ghc` executables it provides. I've pinned `nixpkgs` to a commit that is known to work for us at Active Group and that contains GHC 8.10.4.

The ConCat packages are provided as a nixpkgs overlay (`./nix/concat-overlay.nix`) so that anyone who would want to use them can simply import the Nix expression and use the resulting overlay themselves. (This is also the main motivation for this PR as we're currently maintaining Nix expressions for the packages separately in our project; having them close to the source would enable us to use them for ConCat as well as for our own project).

Note: The `cabal.project` file contains relative paths to git checkouts of `vector-sized` and `netlist`/`netlist-to-verilog`/etc. For the nix-based development setup these are irrelevant as I've included the necessary packages in the `pkgs.haskellPackages` set. The version of `vector-sized` seemed to be recent enough for it to just work.

It's also possible to use `nix-build` to build any ConCat package, like this: `nix-build nix/pkgs.nix -A haskellPackages.concat-known`. But note that `nix-build` by default also runs the test suites, and `concat-examples` (for instance) fails.