### PR TITLE
Improve nix overlay

### DIFF
--- a/nix/concat-overlay.nix
+++ b/nix/concat-overlay.nix
@@ -8,40 +8,41 @@ let
     fetchSubmodules = true;
   };
 in {
-  haskellPackages = super.haskellPackages.override {
-    overrides = hself: hsuper:
-      let
-        defaultMod = drv:
-          super.haskell.lib.disableLibraryProfiling
-          (super.haskell.lib.dontHaddock drv);
-        callCabal2nix = hself.callCabal2nix;
-      in {
-        # Prerequisites
-        netlist =
-          defaultMod (callCabal2nix "netlist" (netlistSrc + /netlist) { });
-        verilog =
-          defaultMod (callCabal2nix "netlist" (netlistSrc + /verilog) { });
-        netlist-to-verilog = defaultMod
-          (callCabal2nix "netlist" (netlistSrc + /netlist-to-verilog) { });
-        netlist-to-vhdl = defaultMod
-          (callCabal2nix "netlist" (netlistSrc + /netlist-to-vhdl) { });
+  haskellPackages = super.haskellPackages.override (old: {
+    overrides = super.lib.composeExtensions (old.overrides or (_: _: { }))
+      (hself: hsuper:
+        let
+          defaultMod = drv:
+            super.haskell.lib.disableLibraryProfiling
+            (super.haskell.lib.dontHaddock drv);
+          callCabal2nix = hself.callCabal2nix;
+        in {
+          # Prerequisites
+          netlist =
+            defaultMod (callCabal2nix "netlist" (netlistSrc + /netlist) { });
+          verilog =
+            defaultMod (callCabal2nix "netlist" (netlistSrc + /verilog) { });
+          netlist-to-verilog = defaultMod
+            (callCabal2nix "netlist" (netlistSrc + /netlist-to-verilog) { });
+          netlist-to-vhdl = defaultMod
+            (callCabal2nix "netlist" (netlistSrc + /netlist-to-vhdl) { });
 
-        # ConCat packages
-        concat-known = defaultMod (callCabal2nix "concat-known" ../known { });
-        concat-satisfy =
-          defaultMod (callCabal2nix "concat-satisfy" ../satisfy { });
-        concat-inline =
-          defaultMod (callCabal2nix "concat-inline" ../inline { });
-        concat-classes =
-          defaultMod (callCabal2nix "concat-classes" ../classes { });
-        concat-plugin =
-          defaultMod (callCabal2nix "concat-plugin" ../plugin { });
-        concat-examples =
-          defaultMod (callCabal2nix "concat-examples" ../examples { });
-        concat-graphics =
-          defaultMod (callCabal2nix "concat-graphics" ../graphics { });
-        concat-hardware =
-          defaultMod (callCabal2nix "concat-hardware" ../hardware { });
-      };
-  };
+          # ConCat packages
+          concat-known = defaultMod (callCabal2nix "concat-known" ../known { });
+          concat-satisfy =
+            defaultMod (callCabal2nix "concat-satisfy" ../satisfy { });
+          concat-inline =
+            defaultMod (callCabal2nix "concat-inline" ../inline { });
+          concat-classes =
+            defaultMod (callCabal2nix "concat-classes" ../classes { });
+          concat-plugin =
+            defaultMod (callCabal2nix "concat-plugin" ../plugin { });
+          concat-examples =
+            defaultMod (callCabal2nix "concat-examples" ../examples { });
+          concat-graphics =
+            defaultMod (callCabal2nix "concat-graphics" ../graphics { });
+          concat-hardware =
+            defaultMod (callCabal2nix "concat-hardware" ../hardware { });
+        });
+  });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 with import ./nix/pkgs.nix;
 pkgs.haskellPackages.shellFor {
-  buildInputs = [ cabal-install ghc ];
+  nativeBuildInputs = [ cabal-install ghc graphviz ];
   packages = p:
     with pkgs.haskellPackages; [
       concat-classes


### PR DESCRIPTION
I'm sorry for the "pull request noise", but I've only today learned two things about Nix that I'd love to change:

- The way I used to specify the Nix overlay for the Haskell packages isn't all that composable when we wish to use multiple overlays that may use each other's packages (see https://github.com/NixOS/nixpkgs/issues/26561).
The solution is to explicitly pass a function that has access to previous overrides and manually thread them through.

- The `nix-shell` development environment now also comes with the `dot` command needed to run the `concat-examples` tests (though the user should take care to include `display`/`open` depending on their system and preferences). It uses `nativeBuildInputs` instead of `buildInputs` to specify the development tooling as that is more robust w.r.t. cross-compilation and seemingly more idiomatic.

If you should accept this, feel free to squash as you'd like of course :)