### PR TITLE
Fix an issue with re-adding the Strength class.

### DIFF
--- a/plugin/src/ConCat/Translators.hs
+++ b/plugin/src/ConCat/Translators.hs
@@ -23,7 +23,7 @@ import Data.Pointed
 import Data.Key (Zip(..))
 
 import ConCat.Misc ((:*),result)
-import ConCat.AltCat
+import ConCat.AltCat hiding (Strong, strength)
 
 -- I could use this simpler style to simplify the plugin, e.g.,
 


### PR DESCRIPTION
Upon rebasing our changes on the latest master, I saw that we actually had another small change required for `Strength` to work. I'm not sure how we diverged from the PR, but this should fix the build.