### PR TITLE
Make it possible to build independently.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,26 @@
+source-repository-package
+  type: git
+  location: https://github.com/ku-fpg/netlist.git
+  tag: master
+  subdir: netlist
+
+source-repository-package
+  type: git
+  location: https://github.com/ku-fpg/netlist.git
+  tag: master
+  subdir: netlist-to-verilog
+
+source-repository-package
+  type: git
+  location: https://github.com/ku-fpg/netlist.git
+  tag: master
+  subdir: verilog
+
+source-repository-package
+  type: git
+  location: https://github.com/expipiplus1/vector-sized.git
+  tag: master
+
 packages:
           ./inline/concat-inline.cabal
           ./plugin/concat-plugin.cabal
@@ -8,8 +31,4 @@ packages:
           ./hardware/concat-hardware.cabal
           ./graphics/concat-graphics.cabal
           ./examples/concat-examples.cabal
-          ./../netlist-kit-kufp/*/*.cabal
-          --- cloned from git@github.com:ku-fpg/netlist.git
-          ./../vector-sized/*.cabal
-          --- cloned from git@github.com:expipiplus1/vector-sized.git
 documentation: False


### PR DESCRIPTION
Rather than expecting other packages to be checked out in particular
places, use source deps that specify the repo and tag that they come
from.

NB: This pins everything to `master`, but a specific commit or tag is
    likely to be more reliable.