### PR TITLE
Don't include coercions in toCcc'' evidence

### DIFF
--- a/satisfy/src/ConCat/BuildDictionary.hs
+++ b/satisfy/src/ConCat/BuildDictionary.hs
@@ -233,7 +233,9 @@ evVarName = mkFastString "evidence"
 
 extendEvVars :: DVarSet -> Var -> DVarSet
 extendEvVars evVars var =
-  if isEvVar var
+  -- isEvType would also include constraints, which are unboxed and
+  -- thus we can't put those in a boxed tuple
+  if isPredTy (varType var)
   then extendDVarSet evVars var
   else evVars
 


### PR DESCRIPTION
These are unboxed, and we can't put them as-is in a boxed tuple.
Also unclear if what we'd need them for.