### PR TITLE
Fix MinMaxFunctorCat.

### DIFF
--- a/classes/src/ConCat/Category.hs
+++ b/classes/src/ConCat/Category.hs
@@ -56,7 +56,7 @@ import Data.Type.Equality ((:~:)(..))
 import qualified Data.Type.Equality as Eq
 import Data.Type.Coercion (Coercion(..))
 import qualified Data.Type.Coercion as Co
-import GHC.Types (Constraint, Type)
+import GHC.Types (Type)
 import Data.Constraint hiding ((&&&),(***),(:=>))
 -- import Debug.Trace
 import Data.Monoid
@@ -1477,8 +1477,8 @@ class (EqCat k a, Ord a) => OrdCat k a where
   greaterThanOrEqual = notC . lessThan     <+ okTT @k @a
   {-# MINIMAL lessThan | greaterThan #-}
 
-class MinMaxCat k a where
-  minC, maxC :: Ok k a => Prod k a a `k` a
+class Ok k a => MinMaxCat k a where
+  minC, maxC :: Prod k a a `k` a
 #if 0
   default minC :: (OrdCat k a, IfCat k a, Ok k a) => Prod k a a `k` a
   default maxC :: (OrdCat k a, IfCat k a, Ok k a) => Prod k a a `k` a
@@ -2355,7 +2355,7 @@ instance (IxProductCat k h, IxProductCat k' h, Zip h) => IxProductCat (k :**: k'
   forkF  = prod . (forkF  *** forkF ) . unzip . fmap unProd
   replF  = replF :**: replF
 
-class (OkFunctor k h, Ok k a, Ord a) => MinMaxFunctorCat k h a where
+class (OkFunctor k h, Ok k a) => MinMaxFunctorCat k h a where
   minimumC :: h a `k` a
   maximumC :: h a `k` a
 
@@ -2370,7 +2370,7 @@ instance MinMax h a => MinMaxFunctorCat (->) h a where
   {-# OPINLINE maximumC #-}
 
 -- needed to construct the typeclass hierarchy for MinMaxFunctorCat
-class (Ord a, OkFunctor k h, Ok k a) => MinMaxFFunctorCat k h a where
+class (OkFunctor k h, Ok k a) => MinMaxFFunctorCat k h a where
   minimumCF :: h a -> (a :* (h a `k` a))
   maximumCF :: h a -> (a :* (h a `k` a))
 
@@ -2385,7 +2385,7 @@ instance MinMaxRep h a => MinMaxFFunctorCat (->) h a where
   {-# OPINLINE minimumCF #-}
   {-# OPINLINE maximumCF #-}
 
-instance (MinMaxFFunctorCat k h a, MinMaxFFunctorCat k' h a) => MinMaxFFunctorCat (k :**: k') h a where
+instance (MinMaxFFunctorCat k h a, MinMaxFFunctorCat k' h a, Ord a) => MinMaxFFunctorCat (k :**: k') h a where
   minimumCF h =
     let (a, f) = minimumCF h
         (a', f') = minimumCF h

--- a/examples/src/ConCat/AdditiveFun.hs
+++ b/examples/src/ConCat/AdditiveFun.hs
@@ -275,7 +275,11 @@ instance Representable f => RepresentableCat (-+>) f where
   {-# OPINLINE tabulateC #-}
   {-# OPINLINE indexC #-}
 
-instance (Ord a, Additive a, Additive1 h, MinMaxFFunctorCat (->) h a) => MinMaxFFunctorCat (-+>) h a where
+instance (Additive a, MinMaxCat (->) a) => MinMaxCat (-+>) a where
+  Abst(minC)
+  Abst(maxC)
+
+instance (Additive a, Additive1 h, MinMaxFFunctorCat (->) h a) => MinMaxFFunctorCat (-+>) h a where
   minimumCF = second abst . (IC.inline minimumCF)
   {-# OPINLINE minimumCF #-}
   maximumCF = second abst . (IC.inline maximumCF)

--- a/examples/src/ConCat/GAD.hs
+++ b/examples/src/ConCat/GAD.hs
@@ -258,7 +258,7 @@ instance (ScalarCat k s, Ok k s, Floating s) => FloatingCat (GD k) s where
 -- TODO: experiment with moving some of these dual derivatives to DualAdditive,
 -- in the style of addD, mulD, etc.
 
-instance (ProductCat k, Ord a) => MinMaxCat (GD k) a where
+instance (ProductCat k, Ok k a, Ord a) => MinMaxCat (GD k) a where
   minC = D (minC &&& cond exl exr . lessThanOrEqual)
   maxC = D (maxC &&& cond exr exl . lessThanOrEqual)
   {-# INLINE minC #-} 
@@ -381,7 +381,7 @@ instance (RepresentableCat (->) g, RepresentableCat k g)
   Linear(indexC)
   Linear(tabulateC)
 
-instance MinMaxFFunctorCat k h a => MinMaxFunctorCat (GD k) h a where
+instance (ProductCat k, MinMaxFFunctorCat k h a, Ord a) => MinMaxFunctorCat (GD k) h a where
   minimumC = abst minimumCF
   {-# INLINE minimumC #-}
   maximumC = abst maximumCF


### PR DESCRIPTION
Had to remove the `Ord a` constraint from the class to use it in
categories that can't satisfy the traditional instances.

I tried using a `MinMaxCat k a` constraint instead, but that required
making more changes to code I'm unfamiliar with, so I currently left it
off.

@mikesperber -- could you please try this to see if I didn't break anything for you use case?