### PR TITLE
Revert "Remove unnecessary Functor constraint."

### DIFF
--- a/classes/src/ConCat/Category.hs
+++ b/classes/src/ConCat/Category.hs
@@ -2029,7 +2029,7 @@ instance (OkFunctor k h, OkFunctor k' h)
       => OkFunctor (k :**: k') h where
   okFunctor = inForkCon (okFunctor @k *** okFunctor @k')
 
-class OkFunctor k h => FunctorCat k h where
+class (Functor h, OkFunctor k h) => FunctorCat k h where
   fmapC :: Ok2 k a b => (a `k` b) -> (h a `k` h b)
   unzipC :: forall a b. Ok2 k a b => h (a :* b) `k` (h a :* h b)
 #if 0


### PR DESCRIPTION
Reverts conal/concat#64, which led to build failure.